### PR TITLE
Re-work page breadcrumbs and lists to be more mobile-friendly

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ from wwdtm import (guest as ww_guest, host as ww_host, panelist as ww_panelist,
 from stats import dicts
 
 #region Global Constants
-APP_VERSION = "4.2.1.1"
+APP_VERSION = "4.2.5"
 
 #endregion
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -17,7 +17,11 @@
     .container { max-width: initial; width: 95%; }
     .dropdown-content { border: 2px solid rgba(0, 0, 0, 0.1); }
     .dropdown-content li>a, .dropdown-content li>span { color: initial; }
-    .page-breadcrumb { margin: 1rem 0; }
+    .page-breadcrumb { background-color: rgba(96, 96, 96, 0.05); margin: 1.25rem 0; padding: 0.25rem 1rem; }
+    .page-breadcrumb ul { list-style: none; padding: 0; }
+    .page-breadcrumb ul li { display: inline; padding: 0; }
+    .page-breadcrumb ul li:first-child { padding: 0 0.5rem 0 0; }
+    .page-breadcrumb ul li:not(:last-child)::after { content: ">"; margin: 0 0.75rem;  }
     .sidenav .divider { margin: 1rem 0; }
     .sidenav ul#sidenav-show-years { margin-left: 1rem; }
     .sidenav li>a { font-size: initial; font-weight: initial; }
@@ -39,7 +43,7 @@
     .guest-show-repeat>a, .host-show-repeat>a, .panelist-show-repeat>a, .scorekeeper-show-repeat>a { border-bottom: none !important; }
     .host-appearance-list>ul, .panelist-appearance-list>ul, .scorekeeper-appearance-list>ul { column-count: 3; column-fill: balance; }
     .materialboxed { margin: 0 auto; }
-    q.scorekeeper-description { font-style: italic; }
+    q.scorekeeper-description { display: inline-block; font-style: italic; }
     ul.show-all-years { list-style: none; column-count: 4;}
     .show-description, .show-notes { white-space: pre-line; }
     .show-repeat>a { border-bottom: none !important; }
@@ -51,6 +55,7 @@
 
 @media (prefers-color-scheme: light) {
     html, button, input, select, textarea { background-color: initial; color: initial; }
+    .page-breadcrumb { background-color: rgba(160, 160, 160, 0.1); }
 }
 
 @media (prefers-color-scheme: dark) {
@@ -86,18 +91,20 @@
     .collection .collection-item { padding: 1.33rem; }
     nav .brand-logo { font-size: 1.0rem; font-weight: 500; left: 45%; transform: translateX(-40%); }
     .col.s12 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
+    .page-breadcrumb { font-size: 110%; line-height: 2.5rem;}
     .guest-block, .host-block, .scorekeeper-block, .show-block { border-left: 2px solid; }
     .row.show-badges { margin-bottom: 0; }
-    ul.panelist-list, ul.guest-list { line-height: 2; }
+    q.scorekeeper-description, ul.host-list li, ul.panelist-list li, ul.guest-list li, ul.scorekeeper-list li { padding-bottom: 1rem; }
     .database-id, .show-bestof, .scorekeeper-emeritus, .show-repeat, .show-nprlink { display: inline-flex; margin-bottom: 0.5rem; }
     .footer-copyright span.right { display: block; float: initial !important; }
+    ul.footer-nav-links { line-height: 2.5rem; }
 }
 
 @media only print {
-    html { margin: 1rem; }
-    nav, div.sidenav, .show-nprlink { display: none; visibility: hidden; }
+    *, html { background-color: initial; color: black !important; margin: 1rem; }
+    nav, div.sidenav, .show-nprlink, .page-breadcrumb { display: none; visibility: hidden; }
     div.label, div.show-block { border: none; }
-    div.show-block { margin-left: 1.5rem; }
+    div.show-block { margin-left: 0; }
     div.row.show-badges { margin-bottom: 1rem; }
     .show-bestof, .show-repeat { background-color: initial; color: initial; padding: initial; }
     .show-bestof>a, .show-repeat>a { color: black; }

--- a/templates/guests/all.html
+++ b/templates/guests/all.html
@@ -3,8 +3,10 @@
 
 {% block content %}
 <div class="page-breadcrumb">
-    <a href="{{ url_for('index') }}">Home</a> &gt;
-    <a href="{{ url_for('get_guests') }}">Guests</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('get_guests') }}">Guests</a>
+        </li>
 </div>
 
 <h1>Guest Details</h1>

--- a/templates/guests/all.html
+++ b/templates/guests/all.html
@@ -7,6 +7,9 @@
         <li>
             <a href="{{ url_for('get_guests') }}">Guests</a>
         </li>
+        <li>
+            All
+        </li>
 </div>
 
 <h1>Guest Details</h1>

--- a/templates/guests/all.html
+++ b/templates/guests/all.html
@@ -5,6 +5,9 @@
 <div class="page-breadcrumb">
     <ul>
         <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
             <a href="{{ url_for('get_guests') }}">Guests</a>
         </li>
         <li>

--- a/templates/guests/guests.html
+++ b/templates/guests/guests.html
@@ -5,6 +5,9 @@
 <div class="page-breadcrumb">
     <ul>
         <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
             Guests
         </li>
 </div>

--- a/templates/guests/guests.html
+++ b/templates/guests/guests.html
@@ -3,7 +3,10 @@
 
 {% block content %}
 <div class="page-breadcrumb">
-    <a href="{{ url_for('index') }}">Home</a>
+    <ul>
+        <li>
+            Guests
+        </li>
 </div>
 
 <h1>Guests</h1>

--- a/templates/guests/single.html
+++ b/templates/guests/single.html
@@ -3,8 +3,13 @@
 
 {% block content %}
 <div class="page-breadcrumb">
-    <a href="{{ url_for('index') }}">Home</a> &gt;
-    <a href="{{ url_for('get_guests') }}">Guests</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('get_guests') }}">Guests</a>
+        </li>
+        <li>
+            {{ guest_name }}
+        </li>
 </div>
 
 <h1>Guest Details</h1>

--- a/templates/guests/single.html
+++ b/templates/guests/single.html
@@ -5,6 +5,9 @@
 <div class="page-breadcrumb">
     <ul>
         <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
             <a href="{{ url_for('get_guests') }}">Guests</a>
         </li>
         <li>

--- a/templates/hosts/all.html
+++ b/templates/hosts/all.html
@@ -3,8 +3,17 @@
 
 {% block content %}
 <div class="page-breadcrumb">
-    <a href="{{ url_for('index') }}">Home</a> &gt;
-    <a href="{{ url_for('get_hosts') }}">Hosts</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            <a href="{{ url_for('get_hosts') }}">Hosts</a>
+        </li>
+        <li>
+            All
+        </li>
+    </ul>
 </div>
 
 <h1>Host Details</h1>

--- a/templates/hosts/hosts.html
+++ b/templates/hosts/hosts.html
@@ -3,7 +3,14 @@
 
 {% block content %}
 <div class="page-breadcrumb">
-    <a href="{{ url_for('index') }}">Home</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            Hosts
+        </li>
+    </ul>
 </div>
 
 <h1>Hosts</h1>

--- a/templates/hosts/single.html
+++ b/templates/hosts/single.html
@@ -3,8 +3,17 @@
 
 {% block content %}
 <div class="page-breadcrumb">
-    <a href="{{ url_for('index') }}">Home</a> &gt;
-    <a href="{{ url_for('get_hosts') }}">Hosts</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            <a href="{{ url_for('get_hosts') }}">Hosts</a>
+        </li>
+        <li>
+            {{ host_name }}
+        </li>
+    </ul>
 </div>
 
 <h1>Host Details</h1>

--- a/templates/pages/about.html
+++ b/templates/pages/about.html
@@ -3,7 +3,14 @@
 
 {% block content %}
 <div class="page-breadcrumb">
-    <a href="{{ url_for('index') }}">Home</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            About
+        </li>
+    </ul>
 </div>
 
 <h1>About</h1>

--- a/templates/pages/site_history.html
+++ b/templates/pages/site_history.html
@@ -3,7 +3,14 @@
 
 {% block content %}
 <div class="page-breadcrumb">
-    <a href="{{ url_for('index') }}">Home</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            Site History
+        </li>
+    </ul>
 </div>
 
 <h1>Site History</h1>

--- a/templates/panelists/all.html
+++ b/templates/panelists/all.html
@@ -3,8 +3,17 @@
 
 {% block content %}
 <div class="page-breadcrumb">
-    <a href="{{ url_for('index') }}">Home</a> &gt;
-    <a href="{{ url_for('get_panelists') }}">Panelists</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            <a href="{{ url_for('get_panelists') }}">Panelists</a>
+        </li>
+        <li>
+            All
+        </li>
+    </ul>
 </div>
 
 <h1>Panelists Details</h1>

--- a/templates/panelists/panelists.html
+++ b/templates/panelists/panelists.html
@@ -3,7 +3,14 @@
 
 {% block content %}
 <div class="page-breadcrumb">
-    <a href="{{ url_for('index') }}">Home</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            Panelists
+        </li>
+    </ul>
 </div>
 
 <h1>Panelists</h1>

--- a/templates/panelists/single.html
+++ b/templates/panelists/single.html
@@ -3,8 +3,17 @@
 
 {% block content %}
 <div class="page-breadcrumb">
-    <a href="{{ url_for('index') }}">Home</a> &gt;
-    <a href="{{ url_for('get_panelists') }}">Panelists</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            <a href="{{ url_for('get_panelists') }}">Panelists</a>
+        </li>
+        <li>
+            {{ panelist_name }}
+        </li>
+    </ul>
 </div>
 
 <h1>Panelist Details</h1>

--- a/templates/scorekeepers/all.html
+++ b/templates/scorekeepers/all.html
@@ -3,8 +3,17 @@
 
 {% block content %}
 <div class="page-breadcrumb">
-    <a href="{{ url_for('index') }}">Home</a> &gt;
-    <a href="{{ url_for('get_scorekeepers') }}">Scorekeepers</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            <a href="{{ url_for('get_scorekeepers') }}">Scorekeepers</a>
+        </li>
+        <li>
+            All
+        </li>
+    </ul>
 </div>
 
 <h1>Scorekeeper Details</h1>

--- a/templates/scorekeepers/scorekeepers.html
+++ b/templates/scorekeepers/scorekeepers.html
@@ -3,7 +3,14 @@
 
 {% block content %}
 <div class="page-breadcrumb">
-    <a href="{{ url_for('index') }}">Home</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            Scorekeepers
+        </li>
+    </ul>
 </div>
 
 <h1>Scorekeepers</h1>

--- a/templates/scorekeepers/single.html
+++ b/templates/scorekeepers/single.html
@@ -3,8 +3,17 @@
 
 {% block content %}
 <div class="page-breadcrumb">
-    <a href="{{ url_for('index') }}">Home</a> &gt;
-    <a href="{{ url_for('get_scorekeepers') }}">Scorekeepers</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            <a href="{{ url_for('get_scorekeepers') }}">Scorekeepers</a>
+        </li>
+        <li>
+            {{ scorekeeper_name }}
+        </li>
+    </ul>
 </div>
 
 <h1>Scorekeeper Details</h1>

--- a/templates/shows/all.html
+++ b/templates/shows/all.html
@@ -3,8 +3,17 @@
 
 {% block content %}
 <div class="page-breadcrumb">
-    <a href="{{ url_for('index') }}">Home</a> &gt;
-    <a href="{{ url_for('get_shows') }}">Shows</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            <a href="{{ url_for('get_shows') }}">Shows</a>
+        </li>
+        <li>
+            All
+        </li>
+    </ul>
 </div>
 
 <h1>All Show Details</h1>

--- a/templates/shows/all_details.html
+++ b/templates/shows/all_details.html
@@ -60,11 +60,13 @@
             {% if show.scorekeeper.description %}
             <q class="scorekeeper-description">{{ show.scorekeeper.description }}</q><br>
             {% endif %}
+            <div>
             {% if show.scorekeeper.guest %}
             Guest:
             {% endif %}
             <a href="{{ url_for('get_scorekeeper_details',
                                 scorekeeper=show.scorekeeper.slug) }}">{{ show.scorekeeper.name }}</a>
+            </div>
         {% else %}
             <span class="data-tbd">TBD</span>
         {% endif %}

--- a/templates/shows/details.html
+++ b/templates/shows/details.html
@@ -55,13 +55,15 @@
         <div class="label">Scorekeeper</div>
         {% if show.scorekeeper.slug != "tbd" %}
             {% if show.scorekeeper.description %}
-            <q class="scorekeeper-description">{{ show.scorekeeper.description }}</q><br>
+            <q class="scorekeeper-description">{{ show.scorekeeper.description }}</q>
             {% endif %}
+            <div>
             {% if show.scorekeeper.guest %}
             Guest:
             {% endif %}
             <a href="{{ url_for('get_scorekeeper_details',
                                 scorekeeper=show.scorekeeper.slug) }}">{{ show.scorekeeper.name }}</a>
+            </div>                        
         {% else %}
             <span class="data-tbd">TBD</span>
         {% endif %}

--- a/templates/shows/shows.html
+++ b/templates/shows/shows.html
@@ -3,7 +3,14 @@
 
 {% block content %}
 <div class="page-breadcrumb">
-    <a href="{{ url_for('index') }}">Home</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            Shows
+        </li>
+    </ul>
 </div>
 
 <h1>Shows</h1>

--- a/templates/shows/single.html
+++ b/templates/shows/single.html
@@ -3,11 +3,24 @@
 
 {% block content %}
 <div class="page-breadcrumb">
-    <a href="{{ url_for('index') }}">Home</a> &gt;
-    <a href="{{ url_for('get_shows') }}">Shows</a> &gt;
-    <a href="{{ url_for('get_shows_year', year=show_date.year) }}">{{ show_date.year }}</a> &gt;
-    <a href="{{ url_for('get_shows_year_month', year=show_date.year, month=show_date.month) }}">
-        {{ show_date.strftime("%B") }}</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            <a href="{{ url_for('get_shows') }}">Shows</a>
+        </li>
+        <li>
+            <a href="{{ url_for('get_shows_year', year=show_date.year) }}">{{ show_date.year }}</a>
+        </li>
+        <li>
+            <a href="{{ url_for('get_shows_year_month', year=show_date.year, month=show_date.month) }}">
+                {{ show_date.strftime("%B") }}</a>        
+        </li>
+        <li>
+            {{ show_date.strftime("%d") }}
+        </li>
+    </ul>
 </div>
 
 <h1>Show Details</h1>

--- a/templates/shows/year.html
+++ b/templates/shows/year.html
@@ -3,8 +3,17 @@
 
 {% block content %}
 <div class="page-breadcrumb">
-    <a href="{{ url_for('index') }}">Home</a> &gt;
-    <a href="{{ url_for('get_shows') }}">Shows</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            <a href="{{ url_for('get_shows') }}">Shows</a>
+        </li>
+        <li>
+            {{ year.year }}
+        </li>
+    </ul>
 </div>
 
 <h1>Shows: {{ year.year }}</h1>

--- a/templates/shows/year_all.html
+++ b/templates/shows/year_all.html
@@ -3,9 +3,20 @@
 
 {% block content %}
 <div class="page-breadcrumb">
-    <a href="{{ url_for('index') }}">Home</a> &gt;
-    <a href="{{ url_for('get_shows') }}">Shows</a> &gt;
-    <a href="{{ url_for('get_shows_year', year=year) }}">{{ year }}</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            <a href="{{ url_for('get_shows') }}">Shows</a>
+        </li>
+        <li>
+            <a href="{{ url_for('get_shows_year', year=year) }}">{{ year }}</a>
+        </li>
+        <li>
+            All
+        </li>
+    </ul>
 </div>
 
 <h1>Show Details: {{ year }}</h1>

--- a/templates/shows/year_month.html
+++ b/templates/shows/year_month.html
@@ -3,9 +3,20 @@
 
 {% block content %}
 <div class="page-breadcrumb">
-    <a href="{{ url_for('index') }}">Home</a> &gt;
-    <a href="{{ url_for('get_shows') }}">Shows</a> &gt;
-    <a href="{{ url_for('get_shows_year', year=year_month.year) }}">{{ year_month.year }}</a>
+    <ul>
+        <li>
+            <a href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li>
+            <a href="{{ url_for('get_shows') }}">Shows</a>
+        </li>
+        <li>
+            <a href="{{ url_for('get_shows_year', year=year_month.year) }}">{{ year_month.year }}</a>
+        </li>
+        <li>
+            {{ year_month.strftime("%B") }}
+        </li>
+    </ul>
 </div>
 
 <h1>Show Details: {{ year_month.strftime("%B %Y") }}</h1>


### PR DESCRIPTION
Convert the page breadcrumbs to be inline lists with additional spacing between each element. Also, increase the spacing between each guest, host, panelist and scorekeeper lists to increase vertical spacing between each entry on devices with smaller screens (< 600px).