### PR TITLE
Adding configurability for recent days ahead and back for index route

### DIFF
--- a/config.dist.json
+++ b/config.dist.json
@@ -12,9 +12,11 @@
         "api_url": "",
         "blog_url": "",
         "graphs_url": "",
-        "ga_property_code": null,
         "reports_url": "",
         "site_url": "",
+        "ga_property_code": null,
+        "recent_days_ahead": 1,
+        "recent_days_back": 31,
         "time_zone": "UTC"
     }
 }


### PR DESCRIPTION
Adding settings.recent_days_ahead and settings.recent_days_back to settings.json and logic to the index route to allow for configurability of the include_days_ahead and/or include_days_back parameters for the libwwdtm call to show.details.retrieve_recent().