### PR TITLE
Fix redirect NPR URLs

### DIFF
--- a/app.py
+++ b/app.py
@@ -710,8 +710,8 @@ def npr_show_redirect(show_date: Text):
                                    show_month=show_date_object.month,
                                    show_day=show_date_object.day,
                                    database_connection=database_connection):
-        current_url_prefix = "http://www.npr.org/programs/wait-wait-dont-tell-me/archive?date="
-        legacy_url_prefix = "http://legacy.npr.org/programs/waitwait/archrndwn"
+        current_url_prefix = "https://www.npr.org/programs/wait-wait-dont-tell-me/archive?date="
+        legacy_url_prefix = "https://legacy.npr.org/programs/waitwait/archrndwn"
         legacy_url_suffix = ".waitwait.html"
         if show_date_object >= datetime(year=2006, month=1, day=7):
             show_date_string = show_date_object.strftime("%m-%d-%Y")

--- a/app.py
+++ b/app.py
@@ -25,7 +25,7 @@ from stats.shows import on_this_day
 from stats.locations import formatting
 
 #region Global Constants
-APP_VERSION = "4.4.2"
+APP_VERSION = "4.4.2.1"
 
 DEFAULT_RECENT_DAYS_AHEAD = 2
 DEFAULT_RECENT_DAYS_BACK = 30


### PR DESCRIPTION
Change the base URLs that are used to generate links to NPR's Wait Wait archive pages to use HTTPS to prevent issues where NPR doubles up query strings in the destination URL, causing 404s.