### PR TITLE
Adding Lightning round start/correct on panelist details page

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,7 +25,7 @@ from stats.shows import on_this_day
 from stats.locations import formatting
 
 #region Global Constants
-APP_VERSION = "4.4.2.3"
+APP_VERSION = "4.4.3"
 
 DEFAULT_RECENT_DAYS_AHEAD = 2
 DEFAULT_RECENT_DAYS_BACK = 30

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -43,6 +43,7 @@
     .guest-show-repeat>a, .host-show-repeat>a, .location-show-repeat>a, .panelist-show-repeat>a, .scorekeeper-show-repeat>a { border-bottom: none !important; }
     .host-appearance-list>ul, .location-appearance-list>ul, .panelist-appearance-list>ul, .scorekeeper-appearance-list>ul { column-count: 3; column-fill: balance; }
     .materialboxed { margin: 0 auto; }
+    .panelist-rank { font-weight: 500; margin-left: 0.25rem; }
     q.scorekeeper-description { display: inline-block; font-style: italic; }
     ul.show-all-years { list-style: none; column-count: 4;}
     .show-description, .show-notes { white-space: pre-line; }

--- a/templates/panelists/details.html
+++ b/templates/panelists/details.html
@@ -122,15 +122,18 @@
                     {{appearance.date}}</a>
                     {% if appearance.score != None %}
                         {{ appearance.score }}
+                        {% if appearance.lightning_round_start != None and appearance.lightning_round_correct != None %}
+                            ({{ appearance.lightning_round_start}} / {{ appearance.lightning_round_correct}})
+                        {% endif %}
                         {% if appearance.rank %}
-                            ({{ rank_map[appearance.rank] }})
+                            <span class="panelist-rank">[{{ rank_map[appearance.rank] }}]</span>
                         {% endif %}
                     {% endif %}
                     {% if appearance.best_of %}
-                        <span class="scorekeeper-show-bestof">Best Of</span>
+                        <span class="panelist-show-bestof">Best Of</span>
                     {% endif %}
                     {% if appearance.repeat_show %}
-                        <span class="scorekeeper-show-repeat">Repeat</span>
+                        <span class="panelist-show-repeat">Repeat</span>
                     {% endif %}
                 </li>
             {% endfor %}


### PR DESCRIPTION
Adding the Lightning round starting score and questions answered correctly to each panelist appearance on panelist details page and tweaked panelist rank styling.