### PR TITLE
Changing "ID" to "DB ID" for guests, hosts, locations, panelists, scorekeepers and shows

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,7 +25,7 @@ from stats.shows import on_this_day
 from stats.locations import formatting
 
 #region Global Constants
-APP_VERSION = "4.4.4"
+APP_VERSION = "4.4.5"
 
 DEFAULT_RECENT_DAYS_AHEAD = 2
 DEFAULT_RECENT_DAYS_BACK = 30

--- a/templates/guests/details.html
+++ b/templates/guests/details.html
@@ -6,7 +6,7 @@
 <div class="guest-block">
 <div class="row guest-badges">
     <div class="col s12">
-        <span class="database-id">ID: {{ guest.id }}</span>
+        <span class="database-id">DB ID: {{ guest.id }}</span>
     </div>
 </div>
 <div class="row">

--- a/templates/hosts/details.html
+++ b/templates/hosts/details.html
@@ -6,7 +6,7 @@
 <div class="host-block">
 <div class="row host-badges">
     <div class="col s12">
-        <span class="database-id">ID: {{ host.id }}</span>
+        <span class="database-id">DB ID: {{ host.id }}</span>
     </div>
 </div>
 <div class="row">

--- a/templates/locations/details.html
+++ b/templates/locations/details.html
@@ -7,7 +7,7 @@
 <div class="location-block">
 <div class="row location-badges">
     <div class="col s12">
-        <span class="database-id">ID: {{ location.id }}</span>
+        <span class="database-id">DB ID: {{ location.id }}</span>
     </div>
 </div>
 

--- a/templates/panelists/details.html
+++ b/templates/panelists/details.html
@@ -6,7 +6,7 @@
 <div class="panelist-block">
 <div class="row panelist-badges">
     <div class="col s12">
-        <span class="database-id">ID: {{ panelist.id }}</span>
+        <span class="database-id">DB ID: {{ panelist.id }}</span>
     </div>
 </div>
 

--- a/templates/scorekeepers/details.html
+++ b/templates/scorekeepers/details.html
@@ -9,7 +9,7 @@
         {% if scorekeeper.slug == 'carl-kasell' %}
         <span class="scorekeeper-emeritus">Scorekeeper Emeritus</span>
         {% endif %}
-        <span class="database-id">ID: {{ scorekeeper.id }}</span>
+        <span class="database-id">DB ID: {{ scorekeeper.id }}</span>
     </div>
 </div>
 

--- a/templates/shows/all_details.html
+++ b/templates/shows/all_details.html
@@ -23,7 +23,7 @@
                                                             day=repeat_show.day) }}">{{ show.original_show_date }}</a></span>
         {% endif %}
         <span class="show-nprlink"><a href="{{ url_for('npr_show_redirect', show_date=show.date) }}">NPR</a></span>
-        <span class="database-id">ID: {{ show.id }}</span>
+        <span class="database-id">DB ID: {{ show.id }}</span>
     </div>
 </div>
 

--- a/templates/shows/details.html
+++ b/templates/shows/details.html
@@ -20,7 +20,7 @@
                                                               day=repeat_show.day) }}">{{ show.original_show_date }}</a></span>
         {% endif %}
         <span class="show-nprlink"><a href="{{ url_for('npr_show_redirect', show_date=show.date) }}">NPR</a></span>
-        <span class="database-id">ID: {{ show.id }}</span>
+        <span class="database-id">DB ID: {{ show.id }}</span>
     </div>
 </div>
 


### PR DESCRIPTION
To reduce confusion regarding sequence of shows, etc., changing the label for object ID from "ID" to "DB ID"