### PR TITLE
Adding Randomizer to Guest, Host, Location, Panelist, Scorekeeper and Show

### DIFF
--- a/stats/__init__.py
+++ b/stats/__init__.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018-2020 Linh Pham
+# Copyright (c) 2018-2021 Linh Pham
 # stats.wwdt.me is relased under the terms of the Apache License 2.0
 """Explicitly listing all stats modules"""
 
-from stats import dicts, locations, shows, utility
+from stats import dicts, locations, random, shows, utility
 
-__all__ = ["dicts", "locations", "shows", "utility"]
+__all__ = ["dicts", "locations", "random", "shows", "utility"]

--- a/stats/random.py
+++ b/stats/random.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018-2021 Linh Pham
+# stats.wwdt.me is relased under the terms of the Apache License 2.0
+"""Retrieve random items from Stats Page database"""
+
+import mysql.connector
+
+#region Retrieve Functions
+def random_guest_slug(database_connection: mysql.connector.connect) -> str:
+    """Return a random guest slug from ww_guests table"""
+
+    database_connection.reconnect()
+    cursor = database_connection.cursor(dictionary=True)
+    query = ("SELECT g.guestslug FROM ww_guests g "
+             "WHERE g.guestslug <> 'none' "
+             "ORDER BY RAND() "
+             "LIMIT 1;")
+    cursor.execute(query)
+    result = cursor.fetchone()
+    cursor.close()
+
+    if not result:
+        return None
+
+    return result["guestslug"]
+
+def random_host_slug(database_connection: mysql.connector.connect) -> str:
+    """Return a random host slug from ww_hosts table"""
+
+    database_connection.reconnect()
+    cursor = database_connection.cursor(dictionary=True)
+    query = ("SELECT h.hostslug FROM ww_hosts h "
+             "WHERE h.hostslug <> 'tbd' "
+             "ORDER BY RAND() "
+             "LIMIT 1;")
+    cursor.execute(query)
+    result = cursor.fetchone()
+    cursor.close()
+
+    if not result:
+        return None
+
+    return result["hostslug"]
+
+def random_location_slug(database_connection: mysql.connector.connect) -> str:
+    """Return a random location slug from ww_locations table"""
+
+    database_connection.reconnect()
+    cursor = database_connection.cursor(dictionary=True)
+    query = ("SELECT l.locationslug FROM ww_locations l "
+             "WHERE l.locationslug <> 'tbd' "
+             "ORDER BY RAND() "
+             "LIMIT 1;")
+    cursor.execute(query)
+    result = cursor.fetchone()
+    cursor.close()
+
+    if not result:
+        return None
+
+    return result["locationslug"]
+
+def random_panelist_slug(database_connection: mysql.connector.connect) -> str:
+    """Return a random panelist slug from ww_panelists table"""
+
+    database_connection.reconnect()
+    cursor = database_connection.cursor(dictionary=True)
+    query = ("SELECT p.panelistslug FROM ww_panelists p "
+             "WHERE p.panelistslug <> 'multiple' "
+             "ORDER BY RAND() "
+             "LIMIT 1;")
+    cursor.execute(query)
+    result = cursor.fetchone()
+    cursor.close()
+
+    if not result:
+        return None
+
+    return result["panelistslug"]
+
+def random_scorekeeper_slug(database_connection: mysql.connector.connect) -> str:
+    """Return a random scorekeeper slug from ww_scorekeepers table"""
+
+    database_connection.reconnect()
+    cursor = database_connection.cursor(dictionary=True)
+    query = ("SELECT sk.scorekeeperslug FROM ww_scorekeepers sk "
+             "WHERE sk.scorekeeperslug <> 'tbd' "
+             "ORDER BY RAND() "
+             "LIMIT 1;")
+    cursor.execute(query)
+    result = cursor.fetchone()
+    cursor.close()
+
+    if not result:
+        return None
+
+    return result["scorekeeperslug"]
+
+def random_show_date(database_connection: mysql.connector.connect) -> str:
+    """Return a random show date from the ww_shows table"""
+
+    database_connection.reconnect()
+    cursor = database_connection.cursor(dictionary=True)
+    query = ("SELECT s.showdate FROM ww_shows s "
+             "WHERE s.showdate <= NOW() "
+             "ORDER BY RAND() "
+             "LIMIT 1;")
+    cursor.execute(query)
+    result = cursor.fetchone()
+    cursor.close()
+
+    if not result:
+        return None
+
+    return result["showdate"].isoformat()
+
+#endregion

--- a/templates/core/nav.html
+++ b/templates/core/nav.html
@@ -25,6 +25,7 @@
             <li><a href="{{ url_for('get_panelists') }}">Panelists</a></li>
             <li><a href="{{ url_for('get_scorekeepers') }}">Scorekeepers</a></li>
             <li><a href="{{ url_for('get_shows') }}">Shows</a></li>
+            <li><a href="{{ url_for('get_shows_random') }}"><i class="material-icons" title="Random Show">shuffle</i></a></li>
             <li><a href="{{ url_for('get_shows_on_this_day') }}">On This Day</a></li>
             <li><a href="#" class="dropdown-trigger" data-target="dropdown-more">
                 More<i class="material-icons right">arrow_drop_down</i></a></li>
@@ -42,6 +43,7 @@
         <li><a href="{{ url_for('get_panelists') }}">Panelists</a></li>
         <li><a href="{{ url_for('get_scorekeepers') }}">Scorekeepers</a></li>
         <li><a href="{{ url_for('get_shows') }}">Shows</a></li>
+        <li><a href="{{ url_for('get_shows_random') }}">Random Show</a></li>
         <li><a href="{{ url_for('get_shows_on_this_day') }}">On This Day</a></li>
         <li><div class="divider"></div></li>
         <li><a href="{{ url_for('about') }}">About</a></li>

--- a/templates/guests/guests.html
+++ b/templates/guests/guests.html
@@ -19,6 +19,10 @@
 </p>
 
 <ul class="collection">
+    <li class="collection-item">
+        <a href="{{ url_for('get_guests_random') }}">Random
+        <i class="material-icons right">shuffle</i></a>
+    </li>
     {% for guest in guests %}
     <li class="collection-item">
         <a href="{{ url_for('get_guest_details', guest=guest.slug) }}">{{ guest.name }}</a>

--- a/templates/hosts/hosts.html
+++ b/templates/hosts/hosts.html
@@ -19,6 +19,10 @@
 </p>
 
 <ul class="collection">
+    <li class="collection-item">
+        <a href="{{ url_for('get_hosts_random') }}">Random
+        <i class="material-icons right">shuffle</i></a>
+    </li>
     {% for host in hosts %}
     <li class="collection-item">
         <a href="{{ url_for('get_host_details', host=host.slug) }}">{{ host.name }}</a>

--- a/templates/locations/locations.html
+++ b/templates/locations/locations.html
@@ -19,6 +19,10 @@
 </p>
 
 <ul class="collection">
+    <li class="collection-item">
+        <a href="{{ url_for('get_locations_random') }}">Random
+        <i class="material-icons right">shuffle</i></a>
+    </li>
     {% for location in locations %}
     {% if "id" in location and not (location.id == 3 or location.id == 38) %}
     <li class="collection-item">

--- a/templates/panelists/panelists.html
+++ b/templates/panelists/panelists.html
@@ -19,6 +19,10 @@
 </p>
 
 <ul class="collection">
+    <li class="collection-item">
+        <a href="{{ url_for('get_panelists_random') }}">Random
+        <i class="material-icons right">shuffle</i></a>
+    </li>
     {% for panelist in panelists %}
     <li class="collection-item">
         <a href="{{ url_for('get_panelist_details', panelist=panelist.slug) }}">{{ panelist.name }}</a>

--- a/templates/scorekeepers/scorekeepers.html
+++ b/templates/scorekeepers/scorekeepers.html
@@ -20,6 +20,10 @@
 </p>
 
 <ul class="collection">
+    <li class="collection-item">
+        <a href="{{ url_for('get_scorekeepers_random') }}">Random
+        <i class="material-icons right">shuffle</i></a>
+    </li>
     {% for scorekeeper in scorekeepers %}
     <li class="collection-item">
         <a href="{{ url_for('get_scorekeeper_details',

--- a/templates/shows/shows.html
+++ b/templates/shows/shows.html
@@ -19,6 +19,10 @@
 </p>
 
 <ul class="collection">
+    <li class="collection-item">
+        <a href="{{ url_for('get_shows_random') }}">Random
+        <i class="material-icons right">shuffle</i></a>
+    </li>
     {% for year in show_years %}
     <li class="collection-item">
         <a href="{{ url_for('get_shows_year', year=year) }}">{{ year }}</a>


### PR DESCRIPTION
Adding the ability to get random guest, host, location, panelist, scorekeeper and show items via a link on their respective page, or random shows in the nav bar and slide-out menu.

Also, remove redundant `time_zone_name`variable from app initialization.