### PR TITLE
Adding meta theme-color header and updating footer with tooltips

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,7 +24,7 @@ from stats.shows import on_this_day
 from stats.locations import formatting
 
 #region Global Constants
-APP_VERSION = "4.6.1"
+APP_VERSION = "4.6.2"
 
 DEFAULT_RECENT_DAYS_AHEAD = 2
 DEFAULT_RECENT_DAYS_BACK = 30

--- a/templates/core/footer.html
+++ b/templates/core/footer.html
@@ -16,7 +16,11 @@
     <div class="footer-copyright">
         <div class="container">
             Copyright &copy; 2007&ndash;{{ current_year(time_zone) }} <a href="http://linhpham.org/">Linh Pham</a>. All rights reserved.
-            <span class="right">R: {{ rendered_at(time_zone) }} | V: {{ app_version }} | L: {{ libwwdtm_version }}</span>
+            <span class="right">
+                <span title="Page Rendered at Time">R: {{ rendered_at(time_zone) }}</span> |
+                <span title="Application Version">V: {{ app_version }}</span> |
+                <span title="libwwdtm Version">L: {{ libwwdtm_version }}</span>
+            </span>
         </div>
     </div>
 </footer>

--- a/templates/core/head.html
+++ b/templates/core/head.html
@@ -1,5 +1,6 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="#0d47a1">
     <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
     {% if site_url and request.path %}
     <link rel="canonical" href="{{ site_url}}{{ request.path }}">


### PR DESCRIPTION
Adding `<meta name="theme-color">` to header to enable theme color support in upcoming version of Safari. Also, updated footer to include tooltips over "R", "V" and "L" info.