### PR TITLE
Bump wwdtm version to 1.2.1.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ python-slugify>=4.0.1
 pytz>=2021.1
 us==1.0.0
 uWSGI>=2.0.19.1
-wwdtm>=1.2.1.4
+wwdtm>=1.2.1.5


### PR DESCRIPTION
Bump required wwdtm library version to 1.2.1.5 to fix location slugify logic that caused 500 errors when location slug string was NULL in the database