### PR TITLE
Bump libwwdtm to 1.2.1.5 to Fix Location Slugify Logic

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,7 +24,7 @@ from stats.shows import on_this_day
 from stats.locations import formatting
 
 #region Global Constants
-APP_VERSION = "4.7.0"
+APP_VERSION = "4.7.0.1"
 
 DEFAULT_RECENT_DAYS_AHEAD = 2
 DEFAULT_RECENT_DAYS_BACK = 30

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ python-slugify>=4.0.1
 pytz>=2021.1
 us==1.0.0
 uWSGI>=2.0.19.1
-wwdtm>=1.2.1.4
+wwdtm>=1.2.1.5


### PR DESCRIPTION
Bump required wwdtm library version to 1.2.1.5 to fix location slugify logic that caused 500 errors when location slug string was NULL in the database